### PR TITLE
Final results for empty transcripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,6 @@ Sonus.init = (options, recognizer) => {
   let transcriptEmpty = true
   csr.on('data', data => {
     const result = data.results[0]
-    const finalEmpty = (data.endpointerType === 'END_OF_UTTERANCE' && transcriptEmpty)
     if (result) {
       transcriptEmpty = false
       if (result.isFinal) {
@@ -105,7 +104,7 @@ Sonus.init = (options, recognizer) => {
       } else {
         sonus.emit('partial-result', result.transcript)
       }
-    } else if (finalEmpty) {
+    } else if (data.endpointerType === 'END_OF_UTTERANCE' && transcriptEmpty) {
       sonus.emit('final-result', "")
     }
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonus",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Open source cross platform decentralized always-on speech recognition framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR is for two things:

According to the [Google Cloud Speech RPC documentation](https://cloud.google.com/speech/reference/rpc/google.cloud.speech.v1beta1#endpointertype) when using `single_utterance` we should stop streaming audio after the `END_OF_UTTERANCE` EndpointerType is received.

When an utterance is complete and there is no transcript (ie: no recognized speech) we should send a `final-result` with an empty string.