### PR TITLE
Arecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ npm install --save sonus
 Generally, running `npm install` should suffice. This module however, requires you to install [SoX](http://sox.sourceforge.net).
 
 ### For most linux disto's
-**Reccomended:** use `arecord`, which comes with most linux distros.
+**Recommended:** use `arecord`, which comes with most linux distros.
 
-Alternativly:
+Alternatively:
 ```
 sudo apt-get install sox libsox-fmt-all
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ npm install --save sonus
 Generally, running `npm install` should suffice. This module however, requires you to install [SoX](http://sox.sourceforge.net).
 
 ### For most linux disto's
+**Reccomended:** use `arecord`, which comes with most linux distros.
+
+Alternativly:
 ```
 sudo apt-get install sox libsox-fmt-all
 ```

--- a/examples/example.js
+++ b/examples/example.js
@@ -9,7 +9,8 @@ const speech = require('@google-cloud/speech')({
 
 const hotwords = [{ file: ROOT_DIR + 'resources/sonus.pmdl', hotword: 'sonus' }]
 const language = "en-US"
-const sonus = Sonus.init({ hotwords, language }, speech)
+//recordProgram can also be 'arecord' which works much better on the Pi and low power devices
+const sonus = Sonus.init({ hotwords, language, recordProgram: "arecord" }, speech)
 
 Sonus.start(sonus)
 console.log('Say "' + hotwords[0].hotword + '"...')

--- a/examples/example.js
+++ b/examples/example.js
@@ -9,8 +9,9 @@ const speech = require('@google-cloud/speech')({
 
 const hotwords = [{ file: ROOT_DIR + 'resources/sonus.pmdl', hotword: 'sonus' }]
 const language = "en-US"
+
 //recordProgram can also be 'arecord' which works much better on the Pi and low power devices
-const sonus = Sonus.init({ hotwords, language, recordProgram: "arecord" }, speech)
+const sonus = Sonus.init({ hotwords, language, recordProgram: "rec" }, speech)
 
 Sonus.start(sonus)
 console.log('Say "' + hotwords[0].hotword + '"...')

--- a/index.js
+++ b/index.js
@@ -5,9 +5,11 @@ const stream = require('stream')
 const {Detector, Models} = require('snowboy')
 
 const ERROR = {
-  NOT_STARTED : "NOT_STARTED",
-  INVALID_INDEX : "INVALID_INDEX"
+  NOT_STARTED: "NOT_STARTED",
+  INVALID_INDEX: "INVALID_INDEX"
 }
+
+let verbose = false;
 
 const CloudSpeechRecognizer = {}
 CloudSpeechRecognizer.init = recognizer => {
@@ -62,6 +64,7 @@ Sonus.init = (options, recognizer) => {
     sonus = new stream.Writable(),
     csr = CloudSpeechRecognizer.init(recognizer)
   sonus.mic = {}
+  sonus.recordProgram = opts.recordProgram
   sonus.started = false
 
   // If we don't have any hotwords passed in, add the default global model
@@ -110,9 +113,9 @@ Sonus.init = (options, recognizer) => {
   })
 
   sonus.trigger = (index, hotword) => {
-    if(sonus.started){
-      try{
-        let triggerHotword = (index == 0)? hotword : models.lookup(index)
+    if (sonus.started) {
+      try {
+        let triggerHotword = (index == 0) ? hotword : models.lookup(index)
         sonus.emit('hotword', index, triggerHotword)
         CloudSpeechRecognizer.startStreaming(opts, sonus.mic, csr)
       } catch (e) {
@@ -129,6 +132,7 @@ Sonus.init = (options, recognizer) => {
 Sonus.start = sonus => {
   sonus.mic = record.start({
     threshold: 0,
+    recordProgram: sonus.recordProgram || "sox",
     verbose: false
   })
 

--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ const ERROR = {
   INVALID_INDEX: "INVALID_INDEX"
 }
 
-let verbose = false;
-
 const CloudSpeechRecognizer = {}
 CloudSpeechRecognizer.init = recognizer => {
   const csr = new stream.Writable()
@@ -132,7 +130,7 @@ Sonus.init = (options, recognizer) => {
 Sonus.start = sonus => {
   sonus.mic = record.start({
     threshold: 0,
-    recordProgram: sonus.recordProgram || "sox",
+    recordProgram: sonus.recordProgram || "rec",
     verbose: false
   })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonus",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Open source cross platform decentralized always-on speech recognition framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using `arecord` is way more performant than `rec` (from `sox`) on linux machines, especially those that are low powered like the Pi and the CHIP. This PR exposes the `recordProgram` parameter to allow users to specify the recording program of their choice. 

To avoid a breaking change, Sonus defaults to 'rec' - also supports 'arecord' and 'sox'.

Usage:
```
const sonus = Sonus.init({ hotwords, language, recordProgram: "arecord" }, speech)
```
Hooray choices!
🚀 