### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ CloudSpeechRecognizer.startStreaming = (options, audioStream, cloudSpeechRecogni
     config: {
       encoding: 'LINEAR16',
       sampleRate: 16000,
-      languageCode: options.language
+      languageCode: options.language,
+      speechContext: options.speechContext || null
     },
     singleUtterance: true,
     interimResults: true,
@@ -130,6 +131,7 @@ Sonus.init = (options, recognizer) => {
 Sonus.start = sonus => {
   sonus.mic = record.start({
     threshold: 0,
+    device: sonus.device || null,
     recordProgram: sonus.recordProgram || "rec",
     verbose: false
   })


### PR DESCRIPTION
added the ability to set [speechContext](https://cloud.google.com/speech/reference/rpc/google.cloud.speech.v1beta1#google.cloud.speech.v1beta1.SpeechContext).

Added ability to set mic device, as in new release of [node-record-lpcm16](https://github.com/gillesdemey/node-record-lpcm16/blob/master/package.json).
Is useful for example using Matrix creator Mic array, passing param - 'device':'mic_channel8'
see [here](https://github.com/matrix-io/matrix-creator-malos/blob/master/src/js_test/test_micarray.js)

I hope this helps.

Thanks