### PR TITLE
Updated node-record-lpcm16 to v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/evancohen/sonus#readme",
   "dependencies": {
     "@google-cloud/speech": "^0.6.0",
-    "node-record-lpcm16": "^0.1.7",
+    "node-record-lpcm16": "^0.2.0",
     "snowboy": "^1.1.0",
     "stream": "0.0.2"
   },


### PR DESCRIPTION
version 0.1.7 of node-record-lpcm16 can't change the device when using arecord. This function was enabled with version 0.2.0