### PR TITLE
replace endpointerType with speechEventType

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ CloudSpeechRecognizer.startStreaming = (options, audioStream, cloudSpeechRecogni
   recognitionStream.on('data', data => {
     if (data) {
       cloudSpeechRecognizer.emit('data', data)
-      if (data.endpointerType === 'END_OF_UTTERANCE') {
+      if (data.speechEventType === 'END_OF_SINGLE_UTTERANCE') {
         cloudSpeechRecognizer.listening = false
         audioStream.unpipe(recognitionStream)
       }
@@ -107,7 +107,7 @@ Sonus.init = (options, recognizer) => {
       } else {
         sonus.emit('partial-result', result.transcript)
       }
-    } else if (data.endpointerType === 'END_OF_UTTERANCE' && transcriptEmpty) {
+    } else if (data.speechEventType === 'END_OF_SINGLE_UTTERANCE' && transcriptEmpty) {
       sonus.emit('final-result', "")
     }
   })


### PR DESCRIPTION
Issue: The hotword+speech to text operation worked the first time, but the speech to text operation failed after detecting the hotword the second time. 

The internal state cloudSpeechRecognizer.listening failed to reset, such that CloudSpeechRecognizer.startStreaming()  does not restart/reset after the second hotword trigger. 

This has to do with the update from google.cloud.speech.v1beta1 to google.cloud.speech.v1 in google-cloud-node/speech: 0.9.0.
Read more : [StreamingRecognizeResponse](https://cloud.google.com/speech/reference/rpc/google.cloud.speech.v1#google.cloud.speech.v1.StreamingRecognizeResponse)

P.S. Thank you contributors for this sweet module!