### PR TITLE
emit error from google speech

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ jspm_packages
 
 # Keyfile
 keyfile.json
+/.idea/

--- a/index.js
+++ b/index.js
@@ -109,6 +109,8 @@ Sonus.init = (options, recognizer) => {
       }
     } else if (data.endpointerType === 'END_OF_UTTERANCE' && transcriptEmpty) {
       sonus.emit('final-result', "")
+    } else if (data.error) {
+      sonus.emit('error', data.error)
     }
   })
 


### PR DESCRIPTION
When Google Speech return an error, it's not emitted by sonus and we didn't know what append. This PR fix that