### PR TITLE
Arecord helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonus",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Open source cross platform decentralized always-on speech recognition framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes the age old problem of #68 (alternative solution to #93). Turns out `arecord` doesn't pipe audio after a given file formats max file size. So you can't record indefinitely, which is the whole point of Sonus 😂. This change keeps track of the number of bytes streamed and restarts the recording process silently (hooray).  

The only downside is that it's not a totally seamless transition from one stream to another. If you're mid-utterance when the change happens, the remainder of the utterance will not be streamed to the cloud detector. But that's better than it stopping completely, so I'll take it 👌